### PR TITLE
Add dllordma_c.so to installed files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ install: lib
 	  _build/libordma.a \
 	  _build/libordma.cma \
 	  _build/libordma.cmxa \
-	  _build/libordma.cmxs
+	  _build/libordma.cmxs \
+	  _build/dllordma_c.so
 
 uninstall:
 	$(OCAML_FIND) remove ordma -destdir $(OCAML_LIBDIR)

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -43,7 +43,7 @@ let make_version_and_meta _ _ =
       "exists_if = \"libordma.cmxs,libordma.cmxa\"\n";
       "archive(byte) = \"libordma.cma\"\n";
       "archive(native) = \"libordma.cmxa\"\n";
-      "linkopts = \"-cclib -lordma_c -cclib -lrdmacm\""
+      "linkopts = \"-cclib -lordma_c -cclib -lrdmacm\"\n"
     ]
   in
   let write_meta = Echo (meta_lines, "META") in


### PR DESCRIPTION
this change add `dllordma_c.so`to the list of files to install so ocamlfind (and jbuilder) can build correctly.
