### PR TITLE
Remove bogus lwt_test dependency

### DIFF
--- a/dune
+++ b/dune
@@ -18,4 +18,5 @@
                echo let summary = major, minor, patch, git_revision")
     )
   )
+  (mode fallback)
 )

--- a/dune
+++ b/dune
@@ -14,7 +14,7 @@
   (action
     (with-stdout-to %{targets}
       (system "echo let git_revision = \\\"$(git describe --all --long --always --dirty)\\\";
-               echo let major, minor, patch = $(git describe --tags --exact-match | sed s/[.]/,/g);
+               echo let major, minor, patch = $(git describe --tags --abbrev=0 | sed s/[.]/,/g);
                echo let summary = major, minor, patch, git_revision")
     )
   )

--- a/ordma.opam
+++ b/ordma.opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ordma"
-version: "0.0.4"
+version: "0.0.5"
 maintainer: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
 authors: "Romain Slootmaekers <romain.slootmaekers@openvstorage.com>"
 homepage: "https://github.com/toolslive/ordma"
@@ -16,7 +16,6 @@ depends: [
   "dune" {build}
   "lwt" {>= "2.5.1"}
   "lwt_log"
-  "lwt_test" {test}
   "cmdliner" {test}
 ]
 depexts: [

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (executables
   (names test lwt_test)
   (libraries ordma cmdliner)
-  (flags -w -27)
+  (flags -w -27 -unsafe-string)
 )
 
 (alias


### PR DESCRIPTION
An bogus dependency on lwt_test sneaked in. Also I bumped the version, and added 
(mode fallback) to the generation of `ordma_version.ml`, so that dune will not complain if the file is there. This makes is easier to publish to opam.